### PR TITLE
Fix RangeError: Maximum call stack size exceeded

### DIFF
--- a/scripts/remind-her.coffee
+++ b/scripts/remind-her.coffee
@@ -34,7 +34,7 @@ chrono_parse = (text, ref) ->
   result = results[0]
   date = result.start.date()
   if time_until(date) <= 0 && result.tags.ENTimeExpressionParser
-    ref = chrono.parse('tomorrow')[0].start.date()
+    ref = chrono.parse('tomorrow', ref)[0].start.date()
     return chrono_parse text, ref
   # console.log "parsed '#{text}' -> #{date}:"
   # console.log result


### PR DESCRIPTION
When a recurring reminder is added on the same day at a time in the past, the script throws a `RangeError` as it keeps calling `chrono_parse` with an incorrect `ref`.

To try it out, use `hubot remind every Wednesday at 6AM to drink beers` where `Wednesday` is today and `6AM` is in the past.